### PR TITLE
chore(dependencies): Update peer dependency of semantic-release to < 25.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "standard-version": "^9.3.2"
   },
   "peerDependencies": {
-    "semantic-release": ">=19.0.0 <20.0.0"
+    "semantic-release": ">=19.0.0 <25.0.0"
   }
 }


### PR DESCRIPTION
plugin works perfectly on SR 24 & it just triggers me every time I see the warning in our build logs.